### PR TITLE
Fix various undefined behaviors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -249,7 +249,9 @@ void display(float dt) {
 			int* pos;
 			switch(players[local_player_id].held_item) {
 				case TOOL_BLOCK:
-					if(!players[local_player_id].input.keys.sprint)
+					if(players[local_player_id].input.keys.sprint)
+						pos = NULL;
+					else
 						pos = camera_terrain_pick(0);
 					break;
 				default:
@@ -473,7 +475,7 @@ void keys(struct window_instance* window, int key, int scancode, int action, int
 		time_t pic_time;
 		time(&pic_time);
 		char pic_name[128];
-		sprintf(pic_name,"screenshots/%i.png",pic_time);
+		sprintf(pic_name,"screenshots/%ld.png",(long)pic_time);
 
 		unsigned char* pic_data = malloc(settings.window_width*settings.window_height*4*2);
 		CHECK_ALLOCATION_ERROR(pic_data)
@@ -488,7 +490,7 @@ void keys(struct window_instance* window, int key, int scancode, int action, int
 		lodepng_encode32_file(pic_name,pic_data+settings.window_width*settings.window_height*4,settings.window_width,settings.window_height);
 		free(pic_data);
 
-		sprintf(pic_name,"Saved screenshot as screenshots/%i.png",pic_time);
+		sprintf(pic_name,"Saved screenshot as screenshots/%ld.png", (long)pic_time);
 		chat_add(0,0x0000FF,pic_name);
 	}
 }

--- a/src/network.c
+++ b/src/network.c
@@ -89,13 +89,21 @@ void read_PacketChatMessage(void* data, int len) {
 					sprintf(n,"%s (Spectator)",players[p->player_id].name);
 					break;
 			}
-			sprintf(m,"%s: %s",n,p->message);
+			sprintf(m,"%s: ",n);
 		} else {
-			sprintf(m,": %s",p->message);
+			sprintf(m,": ");
 		}
 	} else {
-		strcpy(m,p->message);
+		m[0] = 0;
 	}
+
+	size_t m_remaining = sizeof(m) - 1 - strlen(m);
+	size_t body_len = len - offsetof(struct PacketChatMessage, message);
+	if (body_len > m_remaining) {
+		body_len = m_remaining;
+	}
+	strncat(m, p->message, body_len);
+
 	printf("%s\n",m);
 	unsigned int color;
 	switch(p->chat_type) {
@@ -111,6 +119,7 @@ void read_PacketChatMessage(void* data, int len) {
 					color = rgb(gamestate.team_2.red,gamestate.team_2.green,gamestate.team_2.blue);
 					break;
 				case TEAM_SPECTATOR:
+				default:
 					color = rgb(0,0,0);
 					break;
 			}
@@ -911,7 +920,7 @@ int network_update() {
 				case ENET_EVENT_TYPE_RECEIVE:
 				{
 					int id = event.packet->data[0];
-					if(id<sizeof(packets) && *packets[id]!=NULL) {
+					if(id<sizeof(packets)/sizeof(packets[0]) && *packets[id]!=NULL) {
 						//printf("packet id %i\n",id);
 						(*packets[id]) (event.packet->data+1,event.packet->dataLength-1);
 					} else {


### PR DESCRIPTION
- Initialize local variables before their first use
- `time_t` has an implementation-defined type. It must be converted to a specific type before being passed to `sprintf`.
- Fix OOB access to `packets`
- Truncate long chat messages.