### PR TITLE
macOS: Remove GLEW dependency (again)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -26,8 +26,13 @@
 #define USE_GLFW
 
 #ifndef OPENGL_ES
+	#if __APPLE__
+	#define GL_SILENCE_DEPRECATION
+	#include <OpenGL/gl.h>
+	#else
 	#define GLEW_STATIC
 	#include <GL/glew.h>
+	#endif
 
 	#include <enet/enet.h>
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -625,7 +625,7 @@ int main(int argc, char** argv) {
 
 	window_init();
 
-	#ifndef OPENGL_ES
+	#if !defined(OPENGL_ES) && !__APPLE__
 	if(glewInit()) {
 		log_error("Could not load extended OpenGL functions!");
 	}

--- a/src/model.c
+++ b/src/model.c
@@ -666,7 +666,7 @@ void kv6_render(struct kv6_t* kv6, unsigned char team) {
 
 		#ifndef OPENGL_ES
 		if(glx_version) {
-			glEnable(GL_PROGRAM_POINT_SIZE);
+			glEnable(GL_PROGRAM_POINT_SIZE_EXT);
 			glUseProgram(kv6_program);
 			glUniform1f(glGetUniformLocation(kv6_program,"dist_factor"),glx_fog?1.0F/settings.render_distance:0.0F);
 			glUniform1f(glGetUniformLocation(kv6_program,"size"),1.414F*near_plane_height*kv6->scale*(len_x+len_y+len_z)/3.0F);
@@ -703,7 +703,7 @@ void kv6_render(struct kv6_t* kv6, unsigned char team) {
 		#ifndef OPENGL_ES
 		if(glx_version) {
 			glUseProgram(0);
-			glDisable(GL_PROGRAM_POINT_SIZE);
+			glDisable(GL_PROGRAM_POINT_SIZE_EXT);
 		}
 		#endif
 


### PR DESCRIPTION
macOS's OpenGL framework exports every OpenGL function supported by the current (and probably every future) version of macOS, so there is no need for GLEW.