### PR TITLE
Network.c: Allow orientation packets to be sent up to 120 times a second

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1100,7 +1100,7 @@ int network_update() {
 				pos.z = 63.0F - players[local_player_id].pos.y;
 				network_send(PACKET_POSITIONDATA_ID, &pos, sizeof(pos));
 			}
-			if(window_time() - network_orient_update > 0.05F
+			if(window_time() - network_orient_update > (1.0F/120.0F)
 			   && angle3D(network_orient_last.x, network_orient_last.y, network_orient_last.z,
 						  players[local_player_id].orientation.x, players[local_player_id].orientation.y,
 						  players[local_player_id].orientation.z)


### PR DESCRIPTION
0.05F is 50ms. This is limiting the orientation packets to be sent only max 20 times a second.
While this may have been fine previously but its not now.

When staff is watching some player using BS its always not even close to
OpenSpades where we can see most of the mouse moves and gives us far better idea
if player is hacking or not.