### PR TITLE
network.c: Do not send input data for movement when player is airborne

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1061,7 +1061,7 @@ int network_update() {
 			}
 		}
 
-		if(network_logged_in && players[local_player_id].team != TEAM_SPECTATOR && players[local_player_id].alive) {
+		if(network_logged_in && players[local_player_id].team != TEAM_SPECTATOR && players[local_player_id].alive && players[local_player_id].physics.airborne == 0) {
 			if(players[local_player_id].input.keys.packed != network_keys_last) {
 				struct PacketInputData in;
 				in.player_id = local_player_id;


### PR DESCRIPTION
Sending movement player input while the player is airborne is a bad idea.
In example it could cause a player to fly if they were to spam for example key w and jump.
And probably and most likely a whole lot more issues as well.

This simple patch prevents this and does not send the packet if player is airborne (In air)

This should absolutely be TESTED.