### PR TITLE
network.c: Do not send Weapon input when sprinting

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1070,7 +1070,7 @@ int network_update() {
 
 				network_keys_last = players[local_player_id].input.keys.packed;
 			}
-			if(players[local_player_id].input.buttons.packed != network_buttons_last) {
+			if(players[local_player_id].input.buttons.packed != network_buttons_last && players[local_player_id].input.keys.sprint == 0) {
 				struct PacketWeaponInput in;
 				in.player_id = local_player_id;
 				in.primary = players[local_player_id].input.buttons.lmb;


### PR DESCRIPTION
BetterSpades was sending weapon inputs to server even when sprinting because
it was checking only if the weapon input is different to previously sent one.

Fix this by checking if player is sprinting and not allowing such packet to be sent.
(The packets cant do any harm really but players can spam the server with it when sprinting thus creating fake shots)