### PR TITLE
(Wip) Fix UI bug mentioned on issue #145.

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -178,6 +178,13 @@ void window_init() {
 		glfwWindowHint(GLFW_SAMPLES, settings.multisamples);
 	}
 
+	/*
+	#FIXME: This is intended to fix the issue #145.
+	This is dirty because it disables the application-level Hi-DPI support for every installation
+	instead of being applied only to those who needs it.
+	*/
+	glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
+
 	hud_window->impl
 		= glfwCreateWindow(settings.window_width, settings.window_height, "BetterSpades " BETTERSPADES_VERSION,
 						   settings.fullscreen ? glfwGetPrimaryMonitor() : NULL, NULL);


### PR DESCRIPTION
First important question: am I the only one getting the issue #145 ?
Because I am building and running bs on a Mac m1 which seems uncommon.

If It's only a matter of my hardware, I can easily make my patch work only for apple m1 using:
`23:08:06 INFO  main.c:733: Renderer: Apple M1`


The solution found is ugly but I didn't want to modify `micro ui`. Let me know what's your thought.

