### PR TITLE
src: Add restock flag to weapon_set

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -499,7 +499,7 @@ void init() {
 	chunk_init();
 	grenade_init();
 
-	weapon_set(0);
+	weapon_set(false);
 
 	rpc_init();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -499,7 +499,7 @@ void init() {
 	chunk_init();
 	grenade_init();
 
-	weapon_set();
+	weapon_set(0);
 
 	rpc_init();
 }

--- a/src/network.c
+++ b/src/network.c
@@ -279,7 +279,7 @@ void read_PacketStateData(void* data, int len) {
 	local_player_health = 100;
 	local_player_blocks = 50;
 	local_player_grenades = 3;
-	weapon_set();
+	weapon_set(0);
 
 	players[local_player_id].block.red = 111;
 	players[local_player_id].block.green = 111;
@@ -395,7 +395,7 @@ void read_PacketCreatePlayer(void* data, int len) {
 			local_player_blocks = 50;
 			local_player_grenades = 3;
 			local_player_lasttool = TOOL_GUN;
-			weapon_set();
+			weapon_set(0);
 		}
 	}
 }
@@ -645,7 +645,7 @@ void read_PacketRestock(void* data, int len) {
 	local_player_health = 100;
 	local_player_blocks = 50;
 	local_player_grenades = 3;
-	weapon_set();
+	weapon_set(1);
 	sound_create(SOUND_LOCAL, &sound_switch, 0.0F, 0.0F, 0.0F);
 }
 

--- a/src/network.c
+++ b/src/network.c
@@ -279,7 +279,7 @@ void read_PacketStateData(void* data, int len) {
 	local_player_health = 100;
 	local_player_blocks = 50;
 	local_player_grenades = 3;
-	weapon_set(0);
+	weapon_set(false);
 
 	players[local_player_id].block.red = 111;
 	players[local_player_id].block.green = 111;
@@ -395,7 +395,7 @@ void read_PacketCreatePlayer(void* data, int len) {
 			local_player_blocks = 50;
 			local_player_grenades = 3;
 			local_player_lasttool = TOOL_GUN;
-			weapon_set(0);
+			weapon_set(false);
 		}
 	}
 }
@@ -645,7 +645,7 @@ void read_PacketRestock(void* data, int len) {
 	local_player_health = 100;
 	local_player_blocks = 50;
 	local_player_grenades = 3;
-	weapon_set(1);
+	weapon_set(true);
 	sound_create(SOUND_LOCAL, &sound_switch, 0.0F, 0.0F, 0.0F);
 }
 

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -184,11 +184,10 @@ struct kv6_t* weapon_casing(int gun) {
 	}
 }
 
-void weapon_set(int restock) {
-	// players[local_player_id].weapon = WEAPON_SHOTGUN;
-	if (restock == 0) {
+void weapon_set(bool restock) {
+	if(!restock)
 		local_player_ammo = weapon_ammo(players[local_player_id].weapon);
-	}
+
 	local_player_ammo_reserved = weapon_ammo_reserved(players[local_player_id].weapon);
 	weapon_reload_inprogress = 0;
 }

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -184,9 +184,11 @@ struct kv6_t* weapon_casing(int gun) {
 	}
 }
 
-void weapon_set() {
+void weapon_set(int restock) {
 	// players[local_player_id].weapon = WEAPON_SHOTGUN;
-	local_player_ammo = weapon_ammo(players[local_player_id].weapon);
+	if (restock == 0) {
+		local_player_ammo = weapon_ammo(players[local_player_id].weapon);
+	}
 	local_player_ammo_reserved = weapon_ammo_reserved(players[local_player_id].weapon);
 	weapon_reload_inprogress = 0;
 }

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -25,7 +25,7 @@
 #include "model.h"
 
 void weapon_update(void);
-void weapon_set(int restock);
+void weapon_set(bool restock);
 void weapon_reload(void);
 int weapon_reloading(void);
 int weapon_can_reload(void);

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -25,7 +25,7 @@
 #include "model.h"
 
 void weapon_update(void);
-void weapon_set(void);
+void weapon_set(int restock);
 void weapon_reload(void);
 int weapon_reloading(void);
 int weapon_can_reload(void);


### PR DESCRIPTION
When restocking we do not want to set
the ammo of the player to max.
Player has to do that manually and reload.

This basically gave players 30 free bullets.
ofc they dont do any damage (at least shouldn't. They may) but still not nice :)