### PR TITLE
Add Haiku support

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -59,6 +59,10 @@
 #define OS_APPLE
 #endif
 
+#ifdef __HAIKU__
+#define OS_HAIKU
+#endif
+
 #ifndef min
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #endif

--- a/src/file.c
+++ b/src/file.c
@@ -49,6 +49,10 @@ void file_url(char* url) {
 	sprintf(cmd, "xdg-open %s", url);
 	system(cmd);
 #endif
+#ifdef OS_HAIKU
+	sprintf(cmd, "open %s", url);
+	system(cmd);
+#endif
 }
 
 int file_dir_exists(const char* path) {

--- a/src/network.c
+++ b/src/network.c
@@ -843,6 +843,9 @@ void read_PacketVersionGet(void* data, int len) {
 #ifdef OS_APPLE
 	char* os = "BetterSpades (Apple) " GIT_COMMIT_HASH;
 #endif
+#ifdef OS_HAIKU
+	char* os = "BetterSpades (Haiku) " GIT_COMMIT_HASH;
+#endif
 #else
 #ifdef USE_TOUCH
 	char* os = "BetterSpades (Android) " GIT_COMMIT_HASH;

--- a/src/window.c
+++ b/src/window.c
@@ -35,6 +35,10 @@
 #include <unistd.h>
 #endif
 
+#ifdef OS_HAIKU
+#include <kernel/OS.h>
+#endif
+
 #ifdef USE_GLFW
 
 static bool joystick_available = false;
@@ -600,5 +604,10 @@ int window_cpucores() {
 	GetSystemInfo(&info);
 	return info.dwNumberOfProcessors;
 #endif
-	return 1;
+#ifdef OS_HAIKU
+	system_info info;
+	get_system_info(&info);
+	return info.cpu_count;
+#endif
+return 1;
 }


### PR DESCRIPTION
This adds support for building *BetterSpades* on Haiku, but it needs `cmake .. -DCMAKE_EXE_LINKER_FLAGS=-lnetwork` (along with a CMake build type) in order to build. Running it directly from the game directory does work with these changes:
[![betterspades-haiku.png](https://i.postimg.cc/yx5334BK/betterspades-haiku.png)](https://postimg.cc/T5V3BspN)