### PR TITLE
Change glm version from 0.84 to 0.85

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
 	cglm
 	GIT_REPOSITORY	https://github.com/recp/cglm
-	GIT_TAG			v0.8.4
+	GIT_TAG			v0.8.5
 )
 
 set(CGLM_STATIC ON CACHE INTERNAL "")


### PR DESCRIPTION
Fixes error when compiling BetterSpades, without the additional commits