### PR TITLE
Optimization: destroy ENet host on disconnect

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -67,6 +67,11 @@ ENetPeer* peer;
 
 char network_custom_reason[17];
 
+void network_init_host() {
+	client = enet_host_create(NULL, 1, 1, 0, 0); // limit bandwidth here if you want to
+	enet_host_compress_with_range_coder(client);
+}
+
 const char* network_reason_disconnect(int code) {
 	if(*network_custom_reason)
 		return network_custom_reason;
@@ -945,17 +950,21 @@ void network_disconnect() {
 		while(enet_host_service(client, &event, 3000) > 0) {
 			switch(event.type) {
 				case ENET_EVENT_TYPE_RECEIVE: enet_packet_destroy(event.packet); break;
-				case ENET_EVENT_TYPE_DISCONNECT: return;
+				case ENET_EVENT_TYPE_DISCONNECT:
+					enet_host_destroy(client);
+				return;
 			}
 		}
 
 		enet_peer_reset(peer);
+		enet_host_destroy(client);
 	}
 }
 
 int network_connect_sub(char* ip, int port, int version) {
 	ENetAddress address;
 	ENetEvent event;
+	network_init_host();
 	enet_address_set_host(&address, ip);
 	address.port = port;
 	peer = enet_host_connect(client, &address, 1, version);
@@ -1132,8 +1141,6 @@ int network_status() {
 
 void network_init() {
 	enet_initialize();
-	client = enet_host_create(NULL, 1, 1, 0, 0); // limit bandwidth here if you want to
-	enet_host_compress_with_range_coder(client);
 
 	packets[PACKET_POSITIONDATA_ID] = read_PacketPositionData;
 	packets[PACKET_ORIENTATIONDATA_ID] = read_PacketOrientationData;

--- a/src/network.h
+++ b/src/network.h
@@ -31,6 +31,7 @@ int network_connect(char* ip, int port);
 int network_connect_string(char* addr);
 int network_update(void);
 int network_status(void);
+void network_init_host(void);
 void network_init(void);
 
 void read_PacketMapChunk(void* data, int len);


### PR DESCRIPTION
This fixes a problem I've encountered with NAT, where the server port would only be forwarded after a client restart (while OpenSpades only requires you to reconnect, because it destroys the host on disconnect).
The ENet host variable also isn't used after being disconnected, so it's probably best to destroy it.