### PR TITLE
network.c: Send position data if local player in water

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1096,7 +1096,7 @@ int network_update() {
 			if(window_time() - network_pos_update > 1.0F
 			   && (distance3D(network_pos_last.x, network_pos_last.y, network_pos_last.z, players[local_player_id].pos.x,
 							 players[local_player_id].pos.y, players[local_player_id].pos.z)
-				   > 0.01F || (63.f - players[local_player_id].pos.y >= 61 && 63.f - players[local_player_id].pos.y <= 62))) {
+				   > 0.01F || players[local_player_id].pos.y <= 2)) {
 				network_pos_update = window_time();
 				memcpy(&network_pos_last, &players[local_player_id].pos, sizeof(struct Position));
 				struct PacketPositionData pos;

--- a/src/network.c
+++ b/src/network.c
@@ -1094,9 +1094,9 @@ int network_update() {
 			}
 
 			if(window_time() - network_pos_update > 1.0F
-			   && distance3D(network_pos_last.x, network_pos_last.y, network_pos_last.z, players[local_player_id].pos.x,
+			   && (distance3D(network_pos_last.x, network_pos_last.y, network_pos_last.z, players[local_player_id].pos.x,
 							 players[local_player_id].pos.y, players[local_player_id].pos.z)
-				   > 0.01F) {
+				   > 0.01F || (63.f - players[local_player_id].pos.y >= 61 && 63.f - players[local_player_id].pos.y <= 62))) {
 				network_pos_update = window_time();
 				memcpy(&network_pos_last, &players[local_player_id].pos, sizeof(struct Position));
 				struct PacketPositionData pos;


### PR DESCRIPTION
Servers use this info to detect if player is in water and do water damage
based on this.

Sadly pique and etc do so based on the reception of this packet and thus
if we do not send it at all a player can avoid being killed by the water.

Fix the logic so if we are in water we send this position packet in the
specified time intervals regardless of if we moved.