### PR TITLE
Fix weapon reload not stopping when player switches tools

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -66,6 +66,8 @@ void weapon_update() {
 			players[local_player_id].item_disabled = window_time();
 			players[local_player_id].items_show_start = window_time();
 			players[local_player_id].items_show = 1;
+		} else {
+			weapon_reload_inprogress = 0;
 		}
 	} else {
 		if(screen_current == SCREEN_NONE && window_time() - players[local_player_id].item_disabled >= 0.5F) {


### PR DESCRIPTION
On the original client, the weapon reload gets cancelled if you switch of tool while reloading your weapon.
The bundled in server and SpadesX follow this behavior by sending a reload cancel packet, however, BetterSpades proceeds with the reloading anyway.
This PR changes it to be more in line with VOXLAP.