### PR TITLE
Fix xtreme8000#96 error when starting client with aos version in url

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1025,7 +1025,21 @@ int network_identifier_split(char* addr, char* ip_out, int* port_out) {
 	return 1;
 }
 
+char* removeSuffix(char* str) {
+	if(strcmp(str + strlen(str) - 5, ":0.75") == 0) {
+		str[strlen(str) - 5] = '\0';
+	} else if(strcmp(str + strlen(str) - 5, ":0.76") == 0) {
+		str[strlen(str) - 5] = '\0';
+	} else {
+		return str;
+	}
+	return str;
+}
+
 int network_connect_string(char* addr) {
+	// simply remove :0.75 or :0.76 suffix because version selection is
+	// handled in network_connect and read_PacketWorldUpdate
+	addr = removeSuffix(addr);
 	char ip[32];
 	int port;
 	if(!network_identifier_split(addr, ip, &port))

--- a/src/network.c
+++ b/src/network.c
@@ -1024,29 +1024,33 @@ int network_identifier_split(char* addr, char* ip_out, int* port_out) {
 
 	return 1;
 }
-
-char* removeSuffix(char* str) {
-	if(strcmp(str + strlen(str) - 5, ":0.75") == 0) {
-		str[strlen(str) - 5] = '\0';
-	} else if(strcmp(str + strlen(str) - 5, ":0.76") == 0) {
-		str[strlen(str) - 5] = '\0';
-	} else {
-		return str;
+int removeSuffix(char* addr) {
+	size_t strLength = strlen(addr);
+	if(strLength < 6) {
+		// no valid aos url is shorter than 6 characters
+		return 0;
 	}
-	return str;
+
+	if(strcmp(addr + strLength - 5, ":0.75") == 0) {
+		addr[strLength - 5] = '\0';
+	} else if(strcmp(addr + strLength - 5, ":0.76") == 0) {
+		addr[strLength - 5] = '\0';
+	}
+	return 1;
 }
 
 int network_connect_string(char* addr) {
-	// simply remove :0.75 or :0.76 suffix because version selection is
+	// Simply remove :0.75 or :0.76 suffix because version selection is
 	// handled in network_connect and read_PacketWorldUpdate
-	addr = removeSuffix(addr);
+	if (!removeSuffix(addr)) return 0;
+
 	char ip[32];
 	int port;
 	if(!network_identifier_split(addr, ip, &port))
 		return 0;
+
 	return network_connect(ip, port);
 }
-
 int network_update() {
 	if(network_connected) {
 		if(window_time() - network_stats_last >= 1.0F) {


### PR DESCRIPTION
The reason this happens is because network_identifier_split at some point got support for "255.255.255.255" ipv4 format, and if you have the suffix it thinks that it's parsing that. This hotfix works in either case (tested). The information about whether the server is .75 or .76 is not needed as it is already handled heuristically in network_connect and read_PacketWorldUpdate