### PR TITLE
hide hp/ammo in spectator mode as a hotfix for #162

### DIFF
--- a/src/hud.c
+++ b/src/hud.c
@@ -734,53 +734,56 @@ static void hud_ingame_render(mu_Context* ctx, float scalex, float scalef) {
 									 200, 200, ang);
 			}
 
-			int health
-				= is_local ? (players[local_id].alive ? local_player_health : 0) : (players[local_id].alive ? 100 : 0);
-			if(health <= 30)
-				glColor3f(1, 0, 0);
-			else
-				glColor3f(1, 1, 1);
-			char hp[4];
-			sprintf(hp, "%i", health);
-			font_render(settings.window_width / 2.0F - font_length(53.0F * scalef, hp), 53.0F * scalef, 53.0F * scalef,
-						hp);
-			texture_draw(&texture_health, settings.window_width / 2.0F, 44.0F * scalef, 32.0F * scalef, 32.0F * scalef);
+			if(players[local_player_id].team != TEAM_SPECTATOR) {
+				int health = is_local ? (players[local_id].alive ? local_player_health : 0) :
+										(players[local_id].alive ? 100 : 0);
+				if(health <= 30)
+					glColor3f(1, 0, 0);
+				else
+					glColor3f(1, 1, 1);
+				char hp[4];
+				sprintf(hp, "%i", health);
+				font_render(settings.window_width / 2.0F - font_length(53.0F * scalef, hp), 53.0F * scalef,
+							53.0F * scalef, hp);
+				texture_draw(&texture_health, settings.window_width / 2.0F, 44.0F * scalef, 32.0F * scalef,
+							 32.0F * scalef);
 
-			char item_mini_str[32];
-			struct texture* item_mini;
-			int off = 0;
-			glColor3f(1.0F, 1.0F, 0.0F);
-			switch(players[local_id].held_item) {
-				default:
-				case TOOL_BLOCK: off = 64 * scalef;
-				case TOOL_SPADE:
-					item_mini = &texture_block;
-					sprintf(item_mini_str, "%i", is_local ? local_player_blocks : 50);
-					break;
-				case TOOL_GRENADE:
-					item_mini = &texture_grenade;
-					sprintf(item_mini_str, "%i", is_local ? local_player_grenades : 3);
-					break;
-				case TOOL_GUN: {
-					int ammo = is_local ? local_player_ammo : players[local_id].ammo;
-					int ammo_reserve = is_local ? local_player_ammo_reserved : players[local_id].ammo_reserved;
-					sprintf(item_mini_str, "%i-%i", ammo, ammo_reserve);
-					switch(players[local_id].weapon) {
-						case WEAPON_RIFLE: item_mini = &texture_ammo_semi; break;
-						case WEAPON_SMG: item_mini = &texture_ammo_smg; break;
-						case WEAPON_SHOTGUN: item_mini = &texture_ammo_shotgun; break;
+				char item_mini_str[32];
+				struct texture* item_mini;
+				int off = 0;
+				glColor3f(1.0F, 1.0F, 0.0F);
+				switch(players[local_id].held_item) {
+					default:
+					case TOOL_BLOCK: off = 64 * scalef;
+					case TOOL_SPADE:
+						item_mini = &texture_block;
+						sprintf(item_mini_str, "%i", is_local ? local_player_blocks : 50);
+						break;
+					case TOOL_GRENADE:
+						item_mini = &texture_grenade;
+						sprintf(item_mini_str, "%i", is_local ? local_player_grenades : 3);
+						break;
+					case TOOL_GUN: {
+						int ammo = is_local ? local_player_ammo : players[local_id].ammo;
+						int ammo_reserve = is_local ? local_player_ammo_reserved : players[local_id].ammo_reserved;
+						sprintf(item_mini_str, "%i-%i", ammo, ammo_reserve);
+						switch(players[local_id].weapon) {
+							case WEAPON_RIFLE: item_mini = &texture_ammo_semi; break;
+							case WEAPON_SMG: item_mini = &texture_ammo_smg; break;
+							case WEAPON_SHOTGUN: item_mini = &texture_ammo_shotgun; break;
+						}
+						if(ammo == 0)
+							glColor3f(1.0F, 0.0F, 0.0F);
+						break;
 					}
-					if(ammo == 0)
-						glColor3f(1.0F, 0.0F, 0.0F);
-					break;
 				}
-			}
 
-			texture_draw(item_mini, settings.window_width - 44.0F * scalef - off, 44.0F * scalef, 32.0F * scalef,
-						 32.0F * scalef);
-			font_render(settings.window_width - font_length(53.0F * scalef, item_mini_str) - 44.0F * scalef - off,
-						53.0F * scalef, 53.0F * scalef, item_mini_str);
-			glColor3f(1.0F, 1.0F, 1.0F);
+				texture_draw(item_mini, settings.window_width - 44.0F * scalef - off, 44.0F * scalef, 32.0F * scalef,
+							 32.0F * scalef);
+				font_render(settings.window_width - font_length(53.0F * scalef, item_mini_str) - 44.0F * scalef - off,
+							53.0F * scalef, 53.0F * scalef, item_mini_str);
+				glColor3f(1.0F, 1.0F, 1.0F);
+			}
 
 			if(players[local_id].held_item == TOOL_BLOCK) {
 				for(int y = 0; y < 8; y++) {


### PR DESCRIPTION
Matches OpenSpades behaviour. Could be fixed for real if server would send accurate hp/ammo to upon joining spectators